### PR TITLE
Disambiguate Judith and Jude in regex

### DIFF
--- a/lib/bible_ref/languages/english.rb
+++ b/lib/bible_ref/languages/english.rb
@@ -46,7 +46,7 @@ module BibleRef
           'ZEC' => { match: /^zec/,              name: 'Zechariah'              },
           'MAL' => { match: /^mal/,              name: 'Malachi'                },
           'TOB' => { match: /^tob/,              name: 'Tobit'                  },
-          'JDT' => { match: /^(jud|jdt)/,        name: 'Judith'                 },
+          'JDT' => { match: /^(jth|jdth?)/,      name: 'Judith'                 },
           'ESG' => { match: /^(est.*greek|esg)/, name: 'Esther (Greek)'         },
           'WIS' => { match: /^wis(dom)?/,        name: 'Wisdom of Solomon'      },
           'SIR' => { match: /^sir/,              name: 'Sirach'                 },
@@ -88,7 +88,7 @@ module BibleRef
           '1JN' => { match: /^1 ?jo?h?n/,        name: '1 John'                 },
           '2JN' => { match: /^2 ?jo?h?n/,        name: '2 John'                 },
           '3JN' => { match: /^3 ?jo?h?n/,        name: '3 John'                 },
-          'JUD' => { match: /^jud/,              name: 'Jude'                   },
+          'JUD' => { match: /^(jud$|jd$)/,        name: 'Jude'                   },
           'REV' => { match: /^re?v/,             name: 'Revelation'             }
         }
       end

--- a/lib/bible_ref/version.rb
+++ b/lib/bible_ref/version.rb
@@ -1,3 +1,3 @@
 module BibleRef
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/bible_ref/reference_spec.rb
+++ b/spec/bible_ref/reference_spec.rb
@@ -238,10 +238,37 @@ describe BibleRef::Reference do
   end
 
   describe '#book_name' do
-    subject { BibleRef::Reference.new('1 Jn 1') }
+    context 'given the book of John' do
+      subject { BibleRef::Reference.new('1 Jn 1') }
 
-    it 'returns the formatted book name' do
-      expect(subject.book_name).to eq('1 John')
+      it 'returns the formatted book name' do
+        expect(subject.book_name).to eq('1 John')
+      end
     end
+
+    context 'given the book of Judith with the abbreviation "jdt"' do
+      subject { BibleRef::Reference.new('jdt 1:1') }
+
+      it 'returns the book of Judith' do
+        expect(subject.book_name).to eq('Judith')
+      end
+    end
+
+    context 'given the book of Jude with the abbreviation "jud"' do
+      subject { BibleRef::Reference.new('jud 1:1') }
+
+      it 'returns the book of Jude' do
+        expect(subject.book_name).to eq('Jude')
+      end
+    end
+
+    context 'given the book of Jude with the abbreviation "jd"' do
+      subject { BibleRef::Reference.new('jd 1:1') }
+
+      it 'returns the book of Jude' do
+        expect(subject.book_name).to eq('Jude')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Attempts to address part of [#36](https://github.com/seven1m/bible_api/issues/36)

Part of the problem is that the default canon doesn't include the books of Judith or Tobit, which is what the bible_api, and parser generally uses. If I included both book keys into there, the Judith and Tobit regex seemed to work, but at least this should remove judith returning the book of Jude for the book of Judith.