### PR TITLE
Refactor Judith and Jude regex and introduce canon for all english key books

### DIFF
--- a/lib/bible_ref/canons.rb
+++ b/lib/bible_ref/canons.rb
@@ -1,7 +1,8 @@
 require_relative 'canons/protestant'
-
+require_relative 'canons/all'
 module BibleRef
   CANONS = {
-    'protestant' => Canons::Protestant
+    'protestant' => Canons::Protestant,
+    'all' => Canons::All
   }
 end

--- a/lib/bible_ref/canons/all.rb
+++ b/lib/bible_ref/canons/all.rb
@@ -1,0 +1,15 @@
+module BibleRef
+  module Canons
+    class All
+      def books
+        %w(
+          GEN EXO LEV NUM DEU JOS JDG RUT 1SA 2SA 1KI 2KI 1CH 2CH EZR NEH EST JOB
+          PSA PRO ECC SNG ISA JER LAM EZK DAN HOS JOL AMO OBA JON MIC NAM HAB ZEP HAG
+          ZEC MAL TOB JDT ESG WIS SIR BAR LJE S3Y SUS BEL 1MA 2MA 1ES MAN PS2 3MA 2ES
+          4MA MAT MRK LUK JHN ACT ROM 1CO 2CO GAL EPH PHP COL 1TH 2TH 1TI 2TI TIT PHM
+          HEB JAS 1PE 2PE 1JN 2JN 3JN JUD REV
+        )
+      end
+    end
+  end
+end

--- a/lib/bible_ref/languages/english.rb
+++ b/lib/bible_ref/languages/english.rb
@@ -46,7 +46,7 @@ module BibleRef
           'ZEC' => { match: /^zec/,              name: 'Zechariah'              },
           'MAL' => { match: /^mal/,              name: 'Malachi'                },
           'TOB' => { match: /^tob/,              name: 'Tobit'                  },
-          'JDT' => { match: /^(jud|jdt)/,        name: 'Judith'                 },
+          'JDT' => { match: /^(jth|jdth?)/,      name: 'Judith'                 },
           'ESG' => { match: /^(est.*greek|esg)/, name: 'Esther (Greek)'         },
           'WIS' => { match: /^wis(dom)?/,        name: 'Wisdom of Solomon'      },
           'SIR' => { match: /^sir/,              name: 'Sirach'                 },
@@ -88,7 +88,7 @@ module BibleRef
           '1JN' => { match: /^1 ?jo?h?n/,        name: '1 John'                 },
           '2JN' => { match: /^2 ?jo?h?n/,        name: '2 John'                 },
           '3JN' => { match: /^3 ?jo?h?n/,        name: '3 John'                 },
-          'JUD' => { match: /^jud/,              name: 'Jude'                   },
+          'JUD' => { match: /^(jud$|jd$)/,        name: 'Jude'                   },
           'REV' => { match: /^re?v/,             name: 'Revelation'             }
         }
       end

--- a/lib/bible_ref/languages/english.rb
+++ b/lib/bible_ref/languages/english.rb
@@ -46,7 +46,7 @@ module BibleRef
           'ZEC' => { match: /^zec/,              name: 'Zechariah'              },
           'MAL' => { match: /^mal/,              name: 'Malachi'                },
           'TOB' => { match: /^tob/,              name: 'Tobit'                  },
-          'JDT' => { match: /^(jth|jdth?)/,      name: 'Judith'                 },
+          'JDT' => { match: /^(jth|jdth?|judith)/, name: 'Judith'                 },
           'ESG' => { match: /^(est.*greek|esg)/, name: 'Esther (Greek)'         },
           'WIS' => { match: /^wis(dom)?/,        name: 'Wisdom of Solomon'      },
           'SIR' => { match: /^sir/,              name: 'Sirach'                 },
@@ -88,7 +88,7 @@ module BibleRef
           '1JN' => { match: /^1 ?jo?h?n/,        name: '1 John'                 },
           '2JN' => { match: /^2 ?jo?h?n/,        name: '2 John'                 },
           '3JN' => { match: /^3 ?jo?h?n/,        name: '3 John'                 },
-          'JUD' => { match: /^(jud$|jd$)/,        name: 'Jude'                   },
+          'JUD' => { match: /^(jud$|jd$|jude$)/, name: 'Jude'                   },
           'REV' => { match: /^re?v/,             name: 'Revelation'             }
         }
       end

--- a/lib/bible_ref/reference.rb
+++ b/lib/bible_ref/reference.rb
@@ -7,7 +7,7 @@ module BibleRef
     attr_reader :book, :reference, :language, :canon
 
     # Create a new Reference instance by passing in the user-supplied bible reference as a string.
-    def initialize(reference, language: 'eng', canon: 'protestant')
+    def initialize(reference, language: 'eng', canon: 'all')
       @reference = reference
       @details = parse
       @language = language.respond_to?(:book_id) ? language : LANGUAGES.fetch(language.to_s).new

--- a/lib/bible_ref/version.rb
+++ b/lib/bible_ref/version.rb
@@ -1,3 +1,3 @@
 module BibleRef
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/lib/bible_ref/version.rb
+++ b/lib/bible_ref/version.rb
@@ -1,3 +1,3 @@
 module BibleRef
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end

--- a/spec/bible_ref/reference_spec.rb
+++ b/spec/bible_ref/reference_spec.rb
@@ -238,10 +238,37 @@ describe BibleRef::Reference do
   end
 
   describe '#book_name' do
-    subject { BibleRef::Reference.new('1 Jn 1') }
+    context 'given the book of John' do
+      subject { BibleRef::Reference.new('1 Jn 1') }
 
-    it 'returns the formatted book name' do
-      expect(subject.book_name).to eq('1 John')
+      it 'returns the formatted book name' do
+        expect(subject.book_name).to eq('1 John')
+      end
     end
+
+    context 'given the book of Judith with the abbreviation "jdt"' do
+      subject { BibleRef::Reference.new('jdt 1:1') }
+
+      it 'returns the book of Judith' do
+        expect(subject.book_name).to eq('Judith')
+      end
+    end
+
+    context 'given the book of Jude with the abbreviation "jud"' do
+      subject { BibleRef::Reference.new('jud 1:1') }
+
+      it 'returns the book of Jude' do
+        expect(subject.book_name).to eq('Jude')
+      end
+    end
+
+    context 'given the book of Jude with the abbreviation "jd"' do
+      subject { BibleRef::Reference.new('jd 1:1') }
+
+      it 'returns the book of Jude' do
+        expect(subject.book_name).to eq('Jude')
+      end
+    end
+
   end
 end

--- a/spec/bible_ref/reference_spec.rb
+++ b/spec/bible_ref/reference_spec.rb
@@ -213,7 +213,7 @@ describe BibleRef::Reference do
     end
 
     context 'given a book not in the canon' do
-      subject { BibleRef::Reference.new('3 Maccabees 1') }
+      subject { BibleRef::Reference.new('3 Maccabees 1', canon: 'protestant') }
 
       it 'returns nil' do
         expect(subject.book_id).to be_nil
@@ -239,12 +239,61 @@ describe BibleRef::Reference do
 
   describe '#book_name' do
     context 'given the book of John' do
-      subject { BibleRef::Reference.new('1 Jn 1') }
+      subject { BibleRef::Reference.new('1 Jn 1', language: 'eng', canon: 'protestant') }
 
       it 'returns the formatted book name' do
         expect(subject.book_name).to eq('1 John')
       end
     end
+
+    context 'given the book of Tobit with the abbreviation "tob"' do
+      subject { BibleRef::Reference.new('tob 1:1') }
+
+      it 'returns the book of Tobit' do
+        expect(subject.book_name).to eq('Tobit')
+      end
+    end
+
+    context 'given the book of Tobit with no abbreviation' do
+      subject { BibleRef::Reference.new('Tobit 1:1') }
+
+      it 'returns the book of Tobit' do
+        expect(subject.book_name).to eq('Tobit')
+      end
+    end
+
+    context 'given the book of Judith with no abbreviation' do
+      subject { BibleRef::Reference.new('judith 1:1') }
+
+      it 'returns the book of Judith' do
+        expect(subject.book_name).to eq('Judith')
+      end
+    end
+
+    context 'given the book of Judith with no abbreviation and capitalization' do
+      subject { BibleRef::Reference.new('Judith 1:1') }
+
+      it 'returns the book of Judith' do
+        expect(subject.book_name).to eq('Judith')
+      end
+    end
+
+    context 'given the book of Judith with the abbreviation "jth"' do
+      subject { BibleRef::Reference.new('jth 1:1') }
+
+      it 'returns the book of Judith' do
+        expect(subject.book_name).to eq('Judith')
+      end
+    end
+
+    context 'given the book of Judith with the abbreviation "jdth"' do
+      subject { BibleRef::Reference.new('jdth 1:1') }
+
+      it 'returns the book of Judith' do
+        expect(subject.book_name).to eq('Judith')
+      end
+    end
+
 
     context 'given the book of Judith with the abbreviation "jdt"' do
       subject { BibleRef::Reference.new('jdt 1:1') }


### PR DESCRIPTION
Replaces #6 
Fixes [#36](https://github.com/seven1m/bible_api/issues/36)

Introduces new canon for "all" books that mirrors the keys in the hash of `english.rb`. This also replaces the default behavior of the BibleRef to use the all canon instead of the protestant canon. You can still specify the Protestant canon if you want to continue to receive previous behavior, but now in projects like [bible_api](https://github.com/seven1m/bible_api) that use the default behavior they can translate all books regardless of canon.

More tests have been included from #6 to show the new canons and behavior. I ran into an issue where Judith was still returning nil from my pervious pr based on the regex that I had there, from what I can only theorize is maybe a double matching problem in the parser? To ensure that this is no longer the case, I have just included each of the books' full name within their regex. 