### PR TITLE
Add parsing for mk abbreviation

### DIFF
--- a/lib/bible_ref/languages/english.rb
+++ b/lib/bible_ref/languages/english.rb
@@ -64,7 +64,7 @@ module BibleRef
           '2ES' => { match: /^2 ?esd?/,          name: '2 Esdras'               },
           '4MA' => { match: /^4 ?mac?/,          name: '4 Maccabees'            },
           'MAT' => { match: /^mat/,              name: 'Matthew'                },
-          'MRK' => { match: /^ma?rk/,            name: 'Mark'                   },
+          'MRK' => { match: /^(ma?rk|mk)/,       name: 'Mark'                   },
           'LUK' => { match: /^lu?k/,             name: 'Luke'                   },
           'JHN' => { match: /^(john|jn|jhn)/,    name: 'John'                   },
           'ACT' => { match: /^act/,              name: 'Acts'                   },

--- a/lib/bible_ref/languages/portuguese.rb
+++ b/lib/bible_ref/languages/portuguese.rb
@@ -46,7 +46,7 @@ module BibleRef
           'ZEC' => { match: /^zac/,             name: 'Zacarias'          },
           'MAL' => { match: /^mal/,             name: 'Malaquias'         },
           'MAT' => { match: /^mat/,             name: 'Mateus'            },
-          'MRK' => { match: /^mar/,             name: 'Marcos'            },
+          'MRK' => { match: /^(mar|mk)/,        name: 'Marcos'            },
           'LUK' => { match: /^lu/,              name: 'Lucas'             },
           'JHN' => { match: /^jo/,              name: 'João'              },
           'ACT' => { match: /^at/,              name: 'Atos'              },

--- a/lib/bible_ref/languages/romanian.rb
+++ b/lib/bible_ref/languages/romanian.rb
@@ -46,7 +46,7 @@ module BibleRef
           'ZEC' => { match: /^za/,              name: 'Zaharia'               },
           'MAL' => { match: /^mal/,             name: 'Maleahi'               },
           'MAT' => { match: /^mat/,             name: 'Matei'                 },
-          'MRK' => { match: /^mar/,             name: 'Marcu'                 },
+          'MRK' => { match: /^(mar|mk)/,        name: 'Marcu'                 },
           'LUK' => { match: /^lu/,              name: 'Luca'                  },
           'JHN' => { match: /^io/,              name: 'Ioan'                  },
           'ACT' => { match: /^fa/,              name: 'Faptele apostolilor'   },

--- a/lib/bible_ref/version.rb
+++ b/lib/bible_ref/version.rb
@@ -1,3 +1,3 @@
 module BibleRef
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/spec/bible_ref/reference_spec.rb
+++ b/spec/bible_ref/reference_spec.rb
@@ -318,6 +318,60 @@ describe BibleRef::Reference do
         expect(subject.book_name).to eq('Jude')
       end
     end
+    context 'given the book of Mark with an abbreviation Mk' do
+      subject { BibleRef::Reference.new('Mk 1:5') }
 
+      it 'returns the book of Mark' do
+        expect(subject.book_name).to eq('Mark')
+      end
+    end
+
+    context 'given the book of Mark with the full name' do
+      subject { BibleRef::Reference.new('Mark 1:5') }
+
+      it 'returns the book of Mark' do
+        expect(subject.book_name).to eq('Mark')
+      end
+    end
+
+    context 'given the book of Mark with the abbreviation mrk' do
+      subject { BibleRef::Reference.new('Mrk 1:5') }
+
+      it 'returns the book of Mark' do
+        expect(subject.book_name).to eq('Mark')
+      end
+    end
+
+    context 'given the book of Mark with an abbreviation Mk and translation Portuguese' do
+      subject { BibleRef::Reference.new('Mk 1:5', language: 'por') }
+
+      it 'returns the book of Marcos' do
+        expect(subject.book_name).to eq('Marcos')
+      end
+    end
+
+    context 'given the book of Mark with the full name and translation Portuguese' do
+      subject { BibleRef::Reference.new('Mark 1:5', language: 'por') }
+
+      it 'returns the book of Marcos' do
+        expect(subject.book_name).to eq('Marcos')
+      end
+    end
+
+    context 'given the book of Mark with an abbreviation Mk and translation Romanian' do
+      subject { BibleRef::Reference.new('Mk 1:5', language: 'ron') }
+
+      it 'returns the book of Marcu' do
+        expect(subject.book_name).to eq('Marcu')
+      end
+    end
+
+    context 'given the book of Mark with the full name and the translation Romanian' do
+      subject { BibleRef::Reference.new('Mark 1:5', language: 'ron') }
+
+      it 'returns the book of Marcu' do
+        expect(subject.book_name).to eq('Marcu')
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes [#43](https://github.com/seven1m/bible_api/issues/43)

Adds regex for languages minus the Cherokee and Latin languages to parse for the "Mk" abbreviation, and includes more tests for those. It might make more sense to change the Romanian and Portuguese regex to something like "mc", but I worried about Maccabees conflicts, even though I don't see any mentions of those books in the regex listings. I won't lie, I don't really know anything about other translations of the Bible.

I'm not really sure what you want to do about the gem version since I have another pull request out. Kind of depends on which one you want to merge first.

Let me know and I'll adjust my pull requests accordingly.