### PR TITLE
The gem was incorrectly parsing the book of Jude

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ verses = ranges.map do |from_ref, to_ref|
 end
 ```
 
+## Note
+
+When searching a book that contains a single chapter (ie. Obadiah, Philemon, Jude, 2 John, 3 John), you can use either Jude 1 or Jude 1:1 to retrieve verse 1.
+This is quite different from searching a book with multiple chapters.  **John 1** will return all of chapter 1, where as **Jude 1** only returns the first verse.
+
 ## Copyright
 
 Copyright [Tim Morgan](http://timmorgan.org). Licensed MIT.

--- a/lib/bible_ref/languages/base.rb
+++ b/lib/bible_ref/languages/base.rb
@@ -5,6 +5,11 @@ module BibleRef
         fail NotImplementedError, "You must override #books in your language class."
       end
 
+      # Is it a single chapter book?
+      def has_single_chapter?(reference)
+        fail NotImplementedError, "You must override #has_single_chapter? in your language class."
+      end
+
       def book_id(book_name, canon)
         book_name = replace_roman_numerals(book_name)
         return book_name.upcase if books[book_name.upcase] # already normalized

--- a/lib/bible_ref/languages/cherokee.rb
+++ b/lib/bible_ref/languages/cherokee.rb
@@ -4,6 +4,13 @@ require_relative 'base'
 module BibleRef
   module Languages
     class Cherokee < Base
+
+      # Is it a single chapter book?
+      def has_single_chapter?(reference)
+          matches = ['ᏉᎳ ᏆᎵᎹᏂ ᎤᏬᏪᎳᏁᎸᎯ', 'ᏣᏂ ᏔᎵᏁ ᎤᏬᏪᎳᏅᎯ', 'ᏣᏂ ᏦᎢᏁ ᎤᏬᏪᎳᏅᎯ', 'ᏧᏓᏏ ᎤᏬᏪᎳᏅᎯ']
+          return matches.any? { |e| reference.include?(e)  }
+      end
+
       def books
         {
           'MAT' => { name: 'ᎣᏍᏛ ᎧᏃᎮᏛ ᎹᏚ ᎤᏬᏪᎳᏅᎯ' },

--- a/lib/bible_ref/languages/english.rb
+++ b/lib/bible_ref/languages/english.rb
@@ -7,7 +7,7 @@ module BibleRef
 
       # Is it a single chapter book?
       def has_single_chapter?(reference)
-          matches = [/^ob/, /^(jud|jd|jude)/, /^2 ?jo?h?n/, /^3 ?jo?h?n/, /^ph(i?l|m)/]
+          matches = [/^ob/, /^(jude|jd(?!th)|jud(?!ith))/, /^2 ?jo?h?n/, /^3 ?jo?h?n/, /^ph(i?l|m)/]
           return Regexp.union(matches).match?(reference.downcase)
       end
 
@@ -95,7 +95,7 @@ module BibleRef
           '1JN' => { match: /^1 ?jo?h?n/,        name: '1 John'                 },
           '2JN' => { match: /^2 ?jo?h?n/,        name: '2 John'                 },
           '3JN' => { match: /^3 ?jo?h?n/,        name: '3 John'                 },
-          'JUD' => { match: /^(jud|jd|jude)/,    name: 'Jude'                   },
+          'JUD' => { match: /^(jud$|jd$|jude$)/, name: 'Jude'                   },
           'REV' => { match: /^re?v/,             name: 'Revelation'             }
         }
       end

--- a/lib/bible_ref/languages/english.rb
+++ b/lib/bible_ref/languages/english.rb
@@ -4,6 +4,13 @@ require_relative 'base'
 module BibleRef
   module Languages
     class English < Base
+
+      # Is it a single chapter book?
+      def has_single_chapter?(reference)
+          matches = [/^ob/, /^(jud|jd|jude)/, /^2 ?jo?h?n/, /^3 ?jo?h?n/, /^ph(i?l|m)/]
+          return Regexp.union(matches).match?(reference.downcase)
+      end
+
       def books
         {
           'GEN' => { match: /^gen/,              name: 'Genesis'                },
@@ -88,7 +95,7 @@ module BibleRef
           '1JN' => { match: /^1 ?jo?h?n/,        name: '1 John'                 },
           '2JN' => { match: /^2 ?jo?h?n/,        name: '2 John'                 },
           '3JN' => { match: /^3 ?jo?h?n/,        name: '3 John'                 },
-          'JUD' => { match: /^(jud$|jd$|jude$)/, name: 'Jude'                   },
+          'JUD' => { match: /^(jud|jd|jude)/,    name: 'Jude'                   },
           'REV' => { match: /^re?v/,             name: 'Revelation'             }
         }
       end

--- a/lib/bible_ref/languages/latin.rb
+++ b/lib/bible_ref/languages/latin.rb
@@ -4,6 +4,12 @@ require_relative 'base'
 module BibleRef
   module Languages
     class Latin < Base
+      # Is it a single chapter book?
+      def has_single_chapter?(reference)
+        matches = ['Abdias', 'ad Philemonem', 'Joannis II', 'Joannis III', 'Judæ']
+        return matches.any? { |e| reference.include?(e)  }
+      end
+
       def books
         {
           'GEN' => { name: 'Genesis' },

--- a/lib/bible_ref/languages/portuguese.rb
+++ b/lib/bible_ref/languages/portuguese.rb
@@ -4,6 +4,13 @@ require_relative 'base'
 module BibleRef
   module Languages
     class Portuguese < Base
+
+      # Is it a single chapter book?
+      def has_single_chapter?(reference)
+          matches = [/^ob/, /^jud/, /^2 jo/, /^3 jo/, /^fil/]
+          return Regexp.union(matches).match?(reference.downcase)
+      end
+
       def books
         {
           'GEN' => { match: /^g[eê]n/,          name: 'Gênesis'           },

--- a/lib/bible_ref/languages/romanian.rb
+++ b/lib/bible_ref/languages/romanian.rb
@@ -4,6 +4,13 @@ require_relative 'base'
 module BibleRef
   module Languages
     class Romanian < Base
+
+      # Is it a single chapter book?
+      def has_single_chapter?(reference)
+          matches = [/^ob/, /^iud/, /^2 io/, /^3 io/, /^fil/]
+          return Regexp.union(matches).match?(reference.downcase)
+      end
+
       def books
         {
           'GEN' => { match: /^gen/,             name: 'Geneza'                },

--- a/lib/bible_ref/reference.rb
+++ b/lib/bible_ref/reference.rb
@@ -22,7 +22,6 @@ module BibleRef
     def ranges
       return nil unless valid?
       @chapter = nil
-      fix_chapter_for_jude if book_id == 'JUD'
       [@details[:refs]].flatten.map do |ref|
         normalize_range(ref) || normalize_ref(ref)
       end
@@ -102,23 +101,5 @@ module BibleRef
       end
     end
 
-    def fix_chapter_for_jude
-      (start, finish) = @details[:refs]
-      finish ||= start
-      @details[:refs] = [
-        {
-          range: {
-            from: {
-              chapter: 1,
-              verse: start[:chapter]
-            },
-            to: {
-              chapter: 1,
-              verse: finish[:chapter]
-            }
-          }
-        }
-      ]
-    end
   end
 end

--- a/spec/bible_ref/languages_spec.rb
+++ b/spec/bible_ref/languages_spec.rb
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+require_relative '../spec_helper'
+
+describe BibleRef::LANGUAGES do
+
+  describe '#has_single_chapter?' do
+
+    context 'given the book of Philemon' do
+      subject { BibleRef::LANGUAGES.fetch('eng').new }
+
+      it 'has one chapter' do
+        expect(subject.has_single_chapter?('Philemon 3-2')).to be_truthy
+      end
+    end
+
+    context 'given the book of Matthew' do
+      subject { BibleRef::LANGUAGES.fetch('eng').new }
+
+      it 'does not have one chapter' do
+        expect(subject.has_single_chapter?('Matthew 5:1-3')).to be_falsey
+      end
+    end
+
+    context 'given the book of 2 John in Romanian' do
+      subject { BibleRef::LANGUAGES.fetch('ron').new }
+
+      it 'has one chapter' do
+        expect(subject.has_single_chapter?('2 Ioan 1')).to be_truthy
+      end
+    end
+
+    context 'given the book of John in Romanian' do
+      subject { BibleRef::LANGUAGES.fetch('ron').new }
+
+      it 'does not have one chapter' do
+        expect(subject.has_single_chapter?('Iona')).to be_falsey
+      end
+    end
+
+    context 'given the book of 3 John in Cherokee' do
+      subject { BibleRef::LANGUAGES.fetch('chr').new }
+
+      it 'has one chapter' do
+        expect(subject.has_single_chapter?('ᏣᏂ ᏦᎢᏁ ᎤᏬᏪᎳᏅᎯ 4')).to be_truthy
+      end
+    end
+
+    context 'given the book of John in Cherokee' do
+      subject { BibleRef::LANGUAGES.fetch('chr').new }
+
+      it 'does not have one chapter' do
+        expect(subject.has_single_chapter?('ᎣᏍᏛ ᎧᏃᎮᏛ ᏣᏂ ᎤᏬᏪᎳᏅᎯ 5:1')).to be_falsey
+      end
+    end
+
+    context 'given the book of Obadiah in Latin' do
+      subject { BibleRef::LANGUAGES.fetch('lat').new }
+
+      it 'has one chapter' do
+        expect(subject.has_single_chapter?('Abdias 4')).to be_truthy
+      end
+    end
+
+    context 'given the book of John in Latin' do
+      subject { BibleRef::LANGUAGES.fetch('lat').new }
+
+      it 'does not have one chapter' do
+        expect(subject.has_single_chapter?('Joannes 5:1')).to be_falsey
+      end
+    end
+
+    context 'given the book of Philemon in Portuguese' do
+      subject { BibleRef::LANGUAGES.fetch('por').new }
+
+      it 'has one chapter' do
+        expect(subject.has_single_chapter?('Filemom 5-6')).to be_truthy
+      end
+    end
+
+    context 'given the book of Mark in Latin' do
+      subject { BibleRef::LANGUAGES.fetch('lat').new }
+
+      it 'does not have one chapter' do
+        expect(subject.has_single_chapter?('Marcos 4:1')).to be_falsey
+      end
+    end
+
+  end
+
+end

--- a/spec/bible_ref/languages_spec.rb
+++ b/spec/bible_ref/languages_spec.rb
@@ -85,6 +85,14 @@ describe BibleRef::LANGUAGES do
       end
     end
 
+    context 'given the book of Judith in English' do
+      subject { BibleRef::LANGUAGES.fetch('eng').new }
+
+      it 'does not have one chapter' do
+        expect(subject.has_single_chapter?('Judith 4:1')).to be_falsey
+      end
+    end
+
   end
 
 end

--- a/spec/bible_ref/reference_spec.rb
+++ b/spec/bible_ref/reference_spec.rb
@@ -99,7 +99,7 @@ describe BibleRef::Reference do
     end
 
     context 'given the book of Jude with a single verse' do
-      subject { BibleRef::Reference.new('Jude 3') }
+      subject { BibleRef::Reference.new('Jude 1:3') }
 
       it 'returns the proper range' do
         expect(subject.ranges).to eq([
@@ -109,11 +109,21 @@ describe BibleRef::Reference do
       end
     end
 
-    context 'given the book of Jude with a multiple verses' do
-      subject { BibleRef::Reference.new('Jude 3,5,7') }
+    context 'given the book of Jude with no verses' do
+        subject { BibleRef::Reference.new('Jude 1') }
 
-      # TODO: this will require some changes to the parser to properly parse hyphenated chapter ranges
-      xit 'returns the proper range' do
+        it 'returns the proper range' do
+          expect(subject.ranges).to eq([
+            [{ book: 'JUD', chapter: 1 },
+             { book: 'JUD', chapter: 1 }]
+          ])
+        end
+    end
+
+    context 'given the book of Jude with a multiple verses' do
+      subject { BibleRef::Reference.new('Jude 1:3,5,7') }
+
+      it 'returns the proper range' do
         expect(subject.ranges).to eq([
           [{ book: 'JUD', chapter: 1, verse: 3 },
            { book: 'JUD', chapter: 1, verse: 3 }],
@@ -126,7 +136,7 @@ describe BibleRef::Reference do
     end
 
     context 'given the book of Jude with a verse range' do
-      subject { BibleRef::Reference.new('Jude 1-25') }
+      subject { BibleRef::Reference.new('Jude 1:1-25') }
 
       it 'returns the proper range' do
         expect(subject.ranges).to eq([

--- a/spec/bible_ref/reference_spec.rb
+++ b/spec/bible_ref/reference_spec.rb
@@ -8,6 +8,14 @@ describe BibleRef::Reference do
     it 'returns the user-supplied reference' do
       expect(subject.reference).to eq('John 3:16')
     end
+
+    context 'given a single chapter book' do
+      subject { BibleRef::Reference.new('Philemon 8') }
+
+      it 'standardizes the reference' do
+        expect(subject.reference).to eq('Philemon 1:8')
+      end
+    end
   end
 
   describe '#valid?' do
@@ -98,7 +106,7 @@ describe BibleRef::Reference do
       end
     end
 
-    context 'given the book of Jude with a single verse' do
+    context 'given the book of Jude, properly formatted, with a single verse' do
       subject { BibleRef::Reference.new('Jude 1:3') }
 
       it 'returns the proper range' do
@@ -109,19 +117,19 @@ describe BibleRef::Reference do
       end
     end
 
-    context 'given the book of Jude with no verses' do
-        subject { BibleRef::Reference.new('Jude 1') }
+    context 'given the book of Jude, improperly formatted, with a single verse' do
+        subject { BibleRef::Reference.new('Jude 4') }
 
         it 'returns the proper range' do
           expect(subject.ranges).to eq([
-            [{ book: 'JUD', chapter: 1 },
-             { book: 'JUD', chapter: 1 }]
+              [{ book: 'JUD', chapter: 1, verse: 4 },
+              { book: 'JUD', chapter: 1, verse: 4 }]
           ])
         end
     end
 
-    context 'given the book of Jude with a multiple verses' do
-      subject { BibleRef::Reference.new('Jude 1:3,5,7') }
+    context 'given the book of Jude, improperly formatted, with multiple verses' do
+      subject { BibleRef::Reference.new('Jude 3,5,7') }
 
       it 'returns the proper range' do
         expect(subject.ranges).to eq([
@@ -135,16 +143,50 @@ describe BibleRef::Reference do
       end
     end
 
-    context 'given the book of Jude with a verse range' do
-      subject { BibleRef::Reference.new('Jude 1:1-25') }
+    context 'given the book of Obadiah, properly formatted, with a range of verses' do
+      subject { BibleRef::Reference.new('Obadiah 1:1-5') }
 
       it 'returns the proper range' do
         expect(subject.ranges).to eq([
-          [{ book: 'JUD', chapter: 1, verse: 1 },
-           { book: 'JUD', chapter: 1, verse: 25 }]
+          [{ book: 'OBA', chapter: 1, verse: 1 },
+           { book: 'OBA', chapter: 1, verse: 5 }]
         ])
       end
     end
+
+    context 'given the book of Obadiah, improperly formatted, with a range of verses' do
+      subject { BibleRef::Reference.new('Obadiah 3-8') }
+
+      it 'returns the proper range' do
+        expect(subject.ranges).to eq([
+          [{ book: 'OBA', chapter: 1, verse: 3 },
+           { book: 'OBA', chapter: 1, verse: 8 }]
+        ])
+      end
+    end
+
+    context 'given the book of Joannis II, properly formatted, with a range of verses' do
+      subject { BibleRef::Reference.new('Joannis II 1:8-10', language: 'lat') }
+
+      it 'returns the proper range' do
+        expect(subject.ranges).to eq([
+          [{ book: '2JN', chapter: 1, verse: 8 },
+           { book: '2JN', chapter: 1, verse: 10 }]
+        ])
+      end
+    end
+
+    context 'given the book of Joannis II, improperly formatted, with a range of verses' do
+      subject { BibleRef::Reference.new('Joannis II 4-9', language: 'lat') }
+
+      it 'returns the proper range' do
+        expect(subject.ranges).to eq([
+          [{ book: '2JN', chapter: 1, verse: 4 },
+           { book: '2JN', chapter: 1, verse: 9 }]
+        ])
+      end
+    end
+
   end
 
   describe '#normalize' do
@@ -384,4 +426,5 @@ describe BibleRef::Reference do
       end
     end
   end
+
 end


### PR DESCRIPTION
## The Problem

I discovered this issue on the bible_api issue tracker on [Issue #25](https://github.com/seven1m/bible_api/issues/25).  When the gem attempts to parse **Jude 1** it only returns verse 1.  However, when you parse other 1 chapter books like **Philemon 1** or **2 John 1**, you receive all of the verses.  Here is an example demonstrating the issue:

```
require 'bundler'

Bundler.require
ref = BibleRef::Reference.new('John 1')

puts '-- John 1 --'
puts ref.ranges.inspect

ref = BibleRef::Reference.new('Philemon 1')

puts '--- Philemon 1 ---'
puts ref.ranges.inspect

ref = BibleRef::Reference.new('2 John 1')

puts '--- 2 John 1 ---'
puts ref.ranges.inspect

ref = BibleRef::Reference.new('Jude 1')

puts '--- Jude 1 ---'
puts ref.ranges.inspect
```

When I ran this code, here were my results:

```
-- John 1 --
[[{:book=>"JHN", :chapter=>1}, {:book=>"JHN", :chapter=>1}]]
--- Philemon 1 ---
[[{:book=>"PHM", :chapter=>1}, {:book=>"PHM", :chapter=>1}]]
--- 2 John 1 ---
[[{:book=>"2JN", :chapter=>1}, {:book=>"2JN", :chapter=>1}]]
--- Jude 1 ---
[[{:book=>"JUD", :chapter=>1, :verse=>1}, {:book=>"JUD", :chapter=>1, :verse=>1}]]
```

As you can see, Jude returns verse 1 in the ranges which is incorrect.

## The Fix

I removed some old code that was designed to fix how Jude was parsed, but it actually caused Jude to return the wrong response.  I was able to also fix one test that was being skipped due to this fix.  Now when I run my test script from above, here are my results:

```
-- John 1 --
[[{:book=>"JHN", :chapter=>1}, {:book=>"JHN", :chapter=>1}]]
--- Philemon 1 ---
[[{:book=>"PHM", :chapter=>1}, {:book=>"PHM", :chapter=>1}]]
--- 2 John 1 ---
[[{:book=>"2JN", :chapter=>1}, {:book=>"2JN", :chapter=>1}]]
--- Jude 1 ---
[[{:book=>"JUD", :chapter=>1}, {:book=>"JUD", :chapter=>1}]]
```

I hope this helps.  Let me know you have any questions.