### PR TITLE
Fix judges1 returning chapter1 verse1

### DIFF
--- a/lib/bible_ref/languages/english.rb
+++ b/lib/bible_ref/languages/english.rb
@@ -7,7 +7,7 @@ module BibleRef
 
       # Is it a single chapter book?
       def has_single_chapter?(reference)
-          matches = [/^ob/, /^(jude|jd(?!th)|jud(?!ith))/, /^2 ?jo?h?n/, /^3 ?jo?h?n/, /^ph(i?l|m)/]
+          matches = [/^ob/, /^(jude|jd(?!th)|jud(?!ith)(?!ges))/, /^2 ?jo?h?n/, /^3 ?jo?h?n/, /^ph(i?l|m)/]
           return Regexp.union(matches).match?(reference.downcase)
       end
 

--- a/spec/bible_ref/languages_spec.rb
+++ b/spec/bible_ref/languages_spec.rb
@@ -93,6 +93,22 @@ describe BibleRef::LANGUAGES do
       end
     end
 
+    context 'given the book of Jude in English' do
+      subject { BibleRef::LANGUAGES.fetch('eng').new }
+
+      it 'has one chapter' do
+        expect(subject.has_single_chapter?('Jude 1:1')).to be_truthy
+      end
+    end
+
+    context 'given the book of Judges in Englsh' do
+      subject { BibleRef::LANGUAGES.fetch('eng').new }
+
+      it 'does not have one chapter' do
+        expect(subject.has_single_chapter?('Judges 1:1')).to be_falsey
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
The existing regex was correctly saying Jude is a single chapter book
and Judith is not a single chapter book but was incorrectly saying
Judges is a single chapter book

This fixes https://github.com/seven1m/bible_api/issues/45